### PR TITLE
[codex] surface refresh auth and /data permission failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ npm run lint:js
 - **Health endpoint fails**: check container logs, `checks.scheduler_failures`, and `DATA_DIR` write permissions.
 - **Feed files stale**: inspect `/health` `freshness` fields, tune `STALE_UPDATE_THRESHOLD_SECONDS` if needed, and rerun update routines manually.
 - **Scheduler appears idle**: check `/status` for `cron_supported`, `cron_error`, and `last_error` / `consecutive_failures`.
+- **Refresh button says unauthorized**: set `ALLOW_ANONYMOUS_LOCAL_REFRESH=true` for LAN-only use, or configure `APP_REFRESH_TOKEN` and call `/refresh` with auth headers.
+- **`permission denied` writing `/data`**: fix host volume ownership/permissions so container user can write `/data` (`index.m3u`, `index.xml`, `state.json`, `credentials.json`).
 - **No WebUI credentials shown**: clear old `/data/credentials.json` only if intentionally rotating, then restart.
 - **`docker build` fails**: inspect Dockerfile stage for dependency or checksum mismatches.
 

--- a/test_integration.py
+++ b/test_integration.py
@@ -37,6 +37,7 @@ def test_api_endpoints():
         data = response.json()
         assert "channel_count" in data
         assert "cron" in data
+        assert "refresh_access_mode" in data
         print("✅ Status endpoint working")
 
         # Test channels endpoint
@@ -90,7 +91,16 @@ def test_api_endpoints():
         assert "status" in health_data
         assert "timestamp" in health_data
         assert "checks" in health_data
+        assert "data_dir_writable" in health_data["checks"]
         print("✅ Health endpoint working")
+
+        # Test HEAD health endpoint for probe compatibility
+        head_response = client.head("/health")
+        assert head_response.status_code in {
+            200,
+            503,
+        }, f"Health HEAD endpoint failed: {head_response.status_code}"
+        print("✅ Health HEAD endpoint working")
 
         # Test stream codes endpoint
         response = client.get("/stream-codes")

--- a/test_integration.py
+++ b/test_integration.py
@@ -26,7 +26,7 @@ os.environ["WEB_DIR"] = str(Path(__file__).parent / "web")
 from app.server import app
 
 
-def test_api_endpoints():
+def test_api_endpoints():  # noqa: PLR0915
     """Test basic API endpoints."""
     print("🧪 Testing API endpoints...")
 


### PR DESCRIPTION
## Summary
- make refresh failures explicit in WebUI:
  - parse API error details
  - show clear unauthorized guidance when `/refresh` returns 401
  - poll `/status` after refresh trigger so the UI reflects async generation instead of appearing as a no-op
  - display configured `refresh_access_mode` in quick stats
- improve health diagnostics for deployment issues:
  - add `checks.data_dir_writable`
  - include `refresh_access_mode` in `/health` and `/status`
  - add `HEAD /health` endpoint for probe compatibility
- add integration coverage for `refresh_access_mode`, `data_dir_writable`, and `HEAD /health`
- update troubleshooting docs for unauthorized refresh and `/data` permission-denied scenarios

## Validation
- `python3 -m black app/server.py test_integration.py`
- `python3 -m py_compile app/server.py test_integration.py`
- `npm run -s lint:js`
- `npm run -s lint:md`

## Notes
- local runtime tests were not executed here because this environment has Python 3.9 while the project targets 3.11+.
