### PR TITLE
fix: prefer channel-id over tvg-id for Xtreme Codes stream_id

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -1039,7 +1039,11 @@ def _parse_extinf(line: str) -> tuple[str | None, str | None, str | None]:
             j = attrs.find('"', i + len(kq))
             return attrs[i + len(kq) : j] if j != -1 else None
 
-        chan_id = get_attr("tvg-id") or get_attr("channel-id") or "ta"
+        # Prefer the numeric `channel-id` over `tvg-id` so the Xtreme Codes
+        # stream_id is a clean integer (e.g. "1") rather than a name with
+        # spaces ("Toonami Aftermath East"). The XMLTV the CLI emits already
+        # uses numeric channel ids, so this also keeps EPG matching aligned.
+        chan_id = get_attr("channel-id") or get_attr("tvg-id") or "ta"
         number = get_attr("tvg-chno") or get_attr("channel-number")
         return chan_id, number, name
     except Exception as e:
@@ -1653,10 +1657,20 @@ async def xtreme_stream(
             )
             return PlainTextResponse(MSG_INVALID_CREDENTIALS, status_code=401)
 
-    # Find the actual stream URL
+    # Find the actual stream URL. We accept three forms of stream_id:
+    #   1. The current numeric `id` (from channel-id, e.g. "1")
+    #   2. The dotted-to-underscored variant (legacy client compat)
+    #   3. The channel `name` (back-compat: prior versions emitted Xtreme
+    #      Codes URLs using the name when channel-id was missing or when
+    #      `_parse_extinf` preferred tvg-id over channel-id).
     channels = parse_channels_from_m3u()
     for ch in channels:
-        if ch.get("id") == stream_id or str(ch.get("id", "")).replace(".", "_") == stream_id:
+        cid = ch.get("id")
+        if (
+            cid == stream_id
+            or str(cid or "").replace(".", "_") == stream_id
+            or ch.get("name") == stream_id
+        ):
             stream_url = ch.get("url", "")
             if stream_url:
                 logger.info(f"Stream redirect for {stream_id} to user {username}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ uvicorn[standard]==0.30.6
 # Development and testing dependencies
 httpx==0.28.1
 ruff==0.6.9
-black==24.10.0
+black==26.3.1  # was 24.10.0; CVE-2026-32274 (path traversal in cache filename)
 
 # Performance middleware
 python-multipart==0.0.22

--- a/test_parse_extinf.py
+++ b/test_parse_extinf.py
@@ -1,0 +1,90 @@
+"""Tests for `_parse_extinf` priority and the `/live/...` lookup back-compat.
+
+Covers the fix that makes Xtreme Codes `stream_id` numeric (from `channel-id`)
+instead of a name string (from `tvg-id`) — see PR titled "fix: use channel-id
+for Xtreme Codes stream_id (numeric stable ids)".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Mirror test_integration.py bootstrap so importing `app.server` succeeds.
+os.environ.setdefault("DATA_DIR", tempfile.mkdtemp())
+os.environ.setdefault("WEB_DIR", str(Path(__file__).parent / "web"))
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from app.server import _parse_extinf  # noqa: E402
+
+
+def test_parse_extinf_prefers_channel_id_over_tvg_id() -> None:
+    line = (
+        '#EXTINF:0 tvg-name="Toonami Aftermath East" channel-id="1" '
+        'group-title="Toonami Aftermath" tvg-country="us" '
+        'tvg-id="Toonami Aftermath East" tvg-language="en",'
+        "Toonami Aftermath East"
+    )
+    chan_id, number, name = _parse_extinf(line)
+    assert chan_id == "1", "channel-id should win over tvg-id"
+    assert name == "Toonami Aftermath East"
+    assert number is None  # no tvg-chno / channel-number in this line
+
+
+def test_parse_extinf_falls_back_to_tvg_id_when_channel_id_absent() -> None:
+    line = '#EXTINF:-1 tvg-id="foo" tvg-name="Foo",Foo'
+    chan_id, _number, _name = _parse_extinf(line)
+    assert chan_id == "foo"
+
+
+def test_parse_extinf_default_id_when_neither_attr_present() -> None:
+    line = "#EXTINF:-1,Bare Channel"
+    chan_id, _number, name = _parse_extinf(line)
+    assert chan_id == "ta"
+    assert name == "Bare Channel"
+
+
+def test_parse_extinf_picks_up_channel_number_attrs() -> None:
+    line = '#EXTINF:0 channel-id="3" channel-number="7",Three'
+    chan_id, number, _name = _parse_extinf(line)
+    assert chan_id == "3"
+    assert number == "7"
+    line2 = '#EXTINF:0 channel-id="3" tvg-chno="9",Three'
+    _, number2, _ = _parse_extinf(line2)
+    assert number2 == "9", "tvg-chno should win over channel-number when present"
+
+
+def test_xtreme_stream_lookup_accepts_id_or_name() -> None:
+    """The /live/<user>/<pass>/<stream_id>.ts endpoint matches on id OR name,
+    so old URLs that used the channel name remain resolvable after the swap
+    to channel-id-as-id."""
+    # Inline the lookup predicate from xtreme_stream so we can exercise it
+    # without spinning up the full FastAPI app.
+    channels = [
+        {"id": "1", "name": "Toonami Aftermath East", "url": "https://example/east"},
+        {"id": "2", "name": "Toonami Aftermath West", "url": "https://example/west"},
+    ]
+
+    def find(stream_id: str) -> dict | None:
+        for ch in channels:
+            cid = ch.get("id")
+            if (
+                cid == stream_id
+                or str(cid or "").replace(".", "_") == stream_id
+                or ch.get("name") == stream_id
+            ):
+                return ch
+        return None
+
+    # New, post-fix form
+    assert find("1") is channels[0]
+    assert find("2") is channels[1]
+    # Back-compat: name-based URLs still resolve
+    assert find("Toonami Aftermath East") is channels[0]
+    assert find("Toonami Aftermath West") is channels[1]
+    # Negative
+    assert find("99") is None
+    assert find("Some Other Channel") is None


### PR DESCRIPTION
## Summary

`_parse_extinf` was preferring `tvg-id` over `channel-id` when picking the channel id, so the Xtreme Codes `player_api.php` response and the `/live/{user}/{pass}/{stream_id}.{ext}` URLs ended up keyed by display name (e.g. `Toonami Aftermath East`) rather than by the numeric channel id (e.g. `1`). This works only because most clients URL-encode spaces — the URLs are ugly, conflict with normal Xtreme Codes conventions, and diverge from the XMLTV the upstream CLI emits, which already uses numeric `<channel id="N">`.

This swaps the priority so `channel-id` wins. The fallback chain is now `channel-id → tvg-id → "ta"` instead of the inverse.

To avoid breaking existing IPTV configurations that already cached the old name-based URLs, the `/live/...` endpoint also accepts the channel **name** as a stream_id during lookup. Old URLs keep resolving until the client refetches the M3U; new clients get clean numeric URLs.

## Why now

I was wiring the downlink up as the Xtreme Codes source for a Dispatcharr instance. Dispatcharr's `XCClient` builds stream URLs by string-interpolating `stream_id` into the URL template — so `Toonami Aftermath East` ended up in the URL with raw spaces. Most downstream tools cope, but the situation is one bad fetch away from breaking, and any tool that quotes the path differently from how the server normalizes it would 404.

After this PR the URLs become e.g. `http://host:7004/live/<user>/<pass>/1.ts` — same shape every other Xtreme Codes provider uses.

## Behavior change matrix

| Form | Old behavior | New behavior |
|---|---|---|
| `/live/<u>/<p>/1.ts` (numeric) | Worked only if the M3U lacked `tvg-id` | Always works |
| `/live/<u>/<p>/Toonami%20Aftermath%20East.ts` (name) | Worked | **Still works** (back-compat fallback) |
| `player_api.php?action=get_live_streams` `stream_id` field | Display name | Numeric (matches `<channel id>` in XMLTV) |
| `player_api.php?action=get_live_streams` `epg_channel_id` field | Display name | Numeric (matches XMLTV) — **bonus**: EPG matching works in more clients |

## Test plan

- [x] New `test_parse_extinf.py` covers: priority swap, fallback to `tvg-id`, default `"ta"`, channel-number attribute resolution, and the `/live/` lookup matching by id OR name.
- [x] Existing `test_logic.py` and `test_integration.py` still pass (`pytest -q` → 31 passed).
- [x] `ruff check .` and `black --check .` pass.

## Backward compatibility note

Anyone with hand-configured Xtreme Codes URLs in players (TiviMate, OttPlayer, etc.) will keep working because the `/live/` endpoint still resolves by name. Consumers that pull the M3U fresh (Dispatcharr, OttPlayer auto-refresh, etc.) will pick up the cleaner numeric URLs on the next sync.