### PR TITLE
feat: synthesize EPG for channels without upstream schedule

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -794,6 +794,115 @@ async def _detect_cli_supports_run_subcommand(state: dict[str, Any]) -> bool | N
     return None
 
 
+# Channels that the upstream Toonami Aftermath API does not publish a schedule
+# for (MTV97, the Movies marathon, Radio, etc.) still need *some* EPG so that
+# Plex / Channels DVR / Jellyfin show a useful label in the guide. Keys are
+# matched case-insensitively against the channel's display name in the M3U.
+SYNTHETIC_PROGRAMMES: dict[str, dict[str, str]] = {
+    "mtv97": {
+        "title": "MTV97 — Late-90s MTV Block",
+        "description": (
+            "A continuous late-1990s MTV-style block: music videos, MTV "
+            "original programming, and pop culture from the era."
+        ),
+    },
+    "movies": {
+        "title": "Toonami Aftermath Movies",
+        "description": (
+            "A continuous movie marathon featuring films from the Toonami "
+            "Aftermath archive."
+        ),
+    },
+    "toonami aftermath radio": {
+        "title": "Toonami Aftermath Radio",
+        "description": ("Audio-only stream featuring classic broadcast radio content."),
+    },
+}
+
+SYNTHETIC_EPG_DAYS_AHEAD = 7
+
+
+def _format_xmltv_time(dt: datetime) -> str:
+    """Format a UTC datetime as XMLTV's `YYYYMMDDHHMMSS +0000`."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.strftime("%Y%m%d%H%M%S %z")
+
+
+def _synthesize_missing_epg() -> int:
+    """For channels declared in the generated `index.xml` that have zero
+    `<programme>` entries, append a per-day 'always-on' programme spanning
+    the next ``SYNTHETIC_EPG_DAYS_AHEAD`` days so downstream EPG consumers
+    display *something* in the guide.
+
+    Title and description are taken from ``SYNTHETIC_PROGRAMMES`` keyed by
+    the channel's lowercased display name; otherwise a generic template is
+    used. Override the day count with the ``SYNTHETIC_EPG_DAYS`` env var.
+
+    Returns the number of channels that received synthetic programmes.
+    """
+    import xml.etree.ElementTree as ET  # noqa: PLC0415
+
+    if not XML_PATH.exists():
+        return 0
+
+    try:
+        tree = ET.parse(XML_PATH)
+        root = tree.getroot()
+    except ET.ParseError as exc:
+        logger.warning("Could not parse %s for synthetic EPG: %s", XML_PATH, exc)
+        return 0
+
+    channel_ids = [ch.get("id") for ch in root.findall("channel") if ch.get("id")]
+    programmed_ids = {p.get("channel") for p in root.findall("programme")}
+    missing_ids = [cid for cid in channel_ids if cid not in programmed_ids]
+    if not missing_ids:
+        return 0
+
+    id_to_name = {
+        ch.get("id"): (ch.findtext("display-name") or ch.get("id") or "")
+        for ch in root.findall("channel")
+    }
+
+    try:
+        days_ahead = max(
+            1, int(os.environ.get("SYNTHETIC_EPG_DAYS", SYNTHETIC_EPG_DAYS_AHEAD))
+        )
+    except ValueError:
+        days_ahead = SYNTHETIC_EPG_DAYS_AHEAD
+
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    for cid in missing_ids:
+        name = id_to_name.get(cid, cid) or ""
+        synth = SYNTHETIC_PROGRAMMES.get(name.lower()) or {
+            "title": f"{name} — Live Stream",
+            "description": f"Continuous live stream on {name}.",
+        }
+        for day in range(days_ahead):
+            start = now + timedelta(days=day)
+            stop = start + timedelta(days=1)
+            programme = ET.SubElement(
+                root,
+                "programme",
+                {
+                    "start": _format_xmltv_time(start),
+                    "stop": _format_xmltv_time(stop),
+                    "channel": cid,
+                },
+            )
+            ET.SubElement(programme, "title", {"lang": "en"}).text = synth["title"]
+            ET.SubElement(programme, "desc", {"lang": "en"}).text = synth["description"]
+        logger.info(
+            "Synthesized %d daily EPG entries for channel id=%s (%s)",
+            days_ahead,
+            cid,
+            name,
+        )
+
+    tree.write(XML_PATH, encoding="utf-8", xml_declaration=True)
+    return len(missing_ids)
+
+
 async def generate_files() -> dict[str, Any]:
     """
     Generate M3U and XMLTV files using the toonamiaftermath-cli.
@@ -870,6 +979,15 @@ async def generate_files() -> dict[str, Any]:
 
     if not success:
         raise RuntimeError("Failed to generate M3U/XML files after multiple attempts")
+
+    # Some channels (MTV97, Movies, Radio) have no upstream schedule data;
+    # add stub EPG entries so guide consumers don't show them as empty.
+    try:
+        synthesized = _synthesize_missing_epg()
+        if synthesized:
+            logger.info("Augmented XMLTV with synthetic EPG for %d channel(s)", synthesized)
+    except Exception as exc:  # noqa: BLE001  # best-effort enrichment
+        logger.warning("Synthetic EPG enrichment failed: %s", exc)
 
     inferred_supports_run = supports_run_subcommand
     if inferred_supports_run is None and successful_mode:

--- a/app/server.py
+++ b/app/server.py
@@ -841,15 +841,25 @@ def _synthesize_missing_epg() -> int:
 
     Returns the number of channels that received synthetic programmes.
     """
-    import xml.etree.ElementTree as ET  # noqa: PLC0415
+    # defusedxml handles the parse (hardens against billion-laughs / XXE
+    # attacks); the stdlib ET is only used for element construction below,
+    # which doesn't take untrusted input.
+    import xml.etree.ElementTree as ET  # noqa: PLC0415, S405  # nosec B405
+
+    from defusedxml.ElementTree import (  # noqa: PLC0415
+        ParseError as DefusedParseError,
+    )
+    from defusedxml.ElementTree import (
+        parse as defused_parse,
+    )
 
     if not XML_PATH.exists():
         return 0
 
     try:
-        tree = ET.parse(XML_PATH)
+        tree = defused_parse(str(XML_PATH))
         root = tree.getroot()
-    except ET.ParseError as exc:
+    except DefusedParseError as exc:
         logger.warning("Could not parse %s for synthetic EPG: %s", XML_PATH, exc)
         return 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Production dependencies
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
+defusedxml==0.7.1  # hardened XML parsing for synthetic EPG augmentation
 
 # Development and testing dependencies
 httpx==0.28.1

--- a/test_synthetic_epg.py
+++ b/test_synthetic_epg.py
@@ -1,0 +1,155 @@
+"""Tests for the synthetic-EPG fallback (`_synthesize_missing_epg`).
+
+Channels MTV97, Movies, and Toonami Aftermath Radio have no upstream
+schedule on `api.toonamiaftermath.com`, so the CLI emits `<channel>`
+elements without any matching `<programme>` entries. We post-process
+the XMLTV to inject per-day 'always-on' programmes for those channels
+so Plex / Channels DVR / Jellyfin show a useful label in the guide.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Mirror test_integration.py bootstrap so importing `app.server` succeeds.
+os.environ.setdefault("DATA_DIR", tempfile.mkdtemp())
+os.environ.setdefault("WEB_DIR", str(Path(__file__).parent / "web"))
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from app import server  # noqa: E402
+from app.server import (  # noqa: E402
+    _format_xmltv_time,
+    _synthesize_missing_epg,
+)
+
+
+def _write_xml(tmp_path: Path, *, has_mtv_programme: bool = False) -> Path:
+    """Build a sample index.xml that mimics what the CLI emits."""
+    root = ET.Element("tv")
+    for cid, name in [
+        ("1", "Toonami Aftermath East"),
+        ("2", "Toonami Aftermath West"),
+        ("5", "MTV97"),
+        ("6", "Movies"),
+        ("7", "Toonami Aftermath Radio"),
+    ]:
+        ch = ET.SubElement(root, "channel", {"id": cid})
+        ET.SubElement(ch, "display-name", {"lang": "en"}).text = name
+
+    # Real programme for TA East so it's NOT a "missing" channel.
+    p = ET.SubElement(
+        root,
+        "programme",
+        {"start": "20260515000000 +0000", "stop": "20260515003000 +0000", "channel": "1"},
+    )
+    ET.SubElement(p, "title", {"lang": "en"}).text = "Lupin III"
+
+    if has_mtv_programme:
+        # Edge case: MTV already has a programme (don't double up).
+        p2 = ET.SubElement(
+            root,
+            "programme",
+            {"start": "20260515000000 +0000", "stop": "20260515010000 +0000", "channel": "5"},
+        )
+        ET.SubElement(p2, "title").text = "MTV — Existing entry"
+
+    out = tmp_path / "index.xml"
+    ET.ElementTree(root).write(out, encoding="utf-8", xml_declaration=True)
+    return out
+
+
+def _count_programmes(path: Path) -> dict[str, int]:
+    root = ET.parse(path).getroot()
+    counts: dict[str, int] = {}
+    for p in root.findall("programme"):
+        cid = p.get("channel", "")
+        counts[cid] = counts.get(cid, 0) + 1
+    return counts
+
+
+def test_synthesize_fills_only_empty_channels(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(server, "XML_PATH", _write_xml(tmp_path))
+    monkeypatch.setenv("SYNTHETIC_EPG_DAYS", "3")
+
+    augmented = _synthesize_missing_epg()
+    assert augmented == 4, "All 4 channels lacking programmes should be filled"
+
+    counts = _count_programmes(server.XML_PATH)
+    # TA East had 1 real programme; should be untouched.
+    assert counts.get("1") == 1
+    # The 4 channels without upstream data should each get 3 daily blocks.
+    for cid in ("2", "5", "6", "7"):
+        assert counts.get(cid) == 3, f"channel {cid} should have 3 synthetic entries"
+
+
+def test_synthesize_uses_curated_title_when_known(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(server, "XML_PATH", _write_xml(tmp_path))
+    monkeypatch.setenv("SYNTHETIC_EPG_DAYS", "1")
+    _synthesize_missing_epg()
+
+    root = ET.parse(server.XML_PATH).getroot()
+    # MTV97 (channel id 5) should pick up the curated synthetic title.
+    mtv_titles = [
+        p.findtext("title") for p in root.findall("programme") if p.get("channel") == "5"
+    ]
+    assert mtv_titles == ["MTV97 — Late-90s MTV Block"]
+
+    # An "unknown" channel without a curated entry should fall back to a
+    # generic title built from its display name. TA West (id 2) is in our
+    # known set as "Toonami Aftermath West" but it's NOT in SYNTHETIC_PROGRAMMES
+    # by default — verify fallback.
+    west_titles = [
+        p.findtext("title") for p in root.findall("programme") if p.get("channel") == "2"
+    ]
+    assert west_titles == ["Toonami Aftermath West — Live Stream"]
+
+
+def test_synthesize_is_noop_when_all_channels_have_programmes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Build an XML where every channel has at least one programme.
+    root = ET.Element("tv")
+    for cid, name in [("1", "TA East"), ("2", "TA West")]:
+        ch = ET.SubElement(root, "channel", {"id": cid})
+        ET.SubElement(ch, "display-name").text = name
+        p = ET.SubElement(
+            root,
+            "programme",
+            {"start": "20260515000000 +0000", "stop": "20260515003000 +0000", "channel": cid},
+        )
+        ET.SubElement(p, "title").text = f"Show on {name}"
+    path = tmp_path / "index.xml"
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+    monkeypatch.setattr(server, "XML_PATH", path)
+    assert _synthesize_missing_epg() == 0
+
+    counts = _count_programmes(path)
+    assert counts == {"1": 1, "2": 1}, "Existing programmes must not be touched"
+
+
+def test_synthesize_handles_missing_xml(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(server, "XML_PATH", tmp_path / "does-not-exist.xml")
+    assert _synthesize_missing_epg() == 0
+
+
+def test_format_xmltv_time_naive_and_aware_match() -> None:
+    naive = datetime(2026, 5, 15, 12, 30, 0)
+    aware = datetime(2026, 5, 15, 12, 30, 0, tzinfo=UTC)
+    assert _format_xmltv_time(naive) == "20260515123000 +0000"
+    assert _format_xmltv_time(aware) == "20260515123000 +0000"
+
+
+def test_synthesize_clamps_invalid_days_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(server, "XML_PATH", _write_xml(tmp_path))
+    monkeypatch.setenv("SYNTHETIC_EPG_DAYS", "not-a-number")
+    _synthesize_missing_epg()
+    # Falls back to the module default (7) when env var is non-numeric.
+    counts = _count_programmes(server.XML_PATH)
+    assert counts.get("5") == server.SYNTHETIC_EPG_DAYS_AHEAD


### PR DESCRIPTION
## Summary

MTV97, the Movies marathon, and Toonami Aftermath Radio are real channels in the M3U, but `api.toonamiaftermath.com/media?scheduleName=X` returns `[]` for them — they're 24/7 themed streams without published schedules. The upstream CLI logs *No Guide Data. Skipping…* and moves on, so any downstream EPG consumer (Plex, Channels DVR, Jellyfin) shows nothing in the guide for those channels.

This PR adds a post-process step in `generate_files()` that, after the CLI runs, scans the generated `index.xml` for `<channel>` elements with **zero** matching `<programme>` entries and injects per-day **always-on** programmes spanning the next 7 days. Each refresh regenerates the window so the guide stays current.

Titles + descriptions come from a small curated dict (`SYNTHETIC_PROGRAMMES`) keyed on the channel's display name, with a generic `"{name} — Live Stream"` fallback for anything else.

## Channels covered out of the box

| Channel | Synthetic title |
|---|---|
| MTV97 | `MTV97 — Late-90s MTV Block` |
| Movies | `Toonami Aftermath Movies` |
| Toonami Aftermath Radio | `Toonami Aftermath Radio` |
| anything else without upstream data | `{display-name} — Live Stream` |

Adding a new channel? Add an entry to `SYNTHETIC_PROGRAMMES` keyed on the lowercased display name.

## Config

- `SYNTHETIC_EPG_DAYS` (env, default `7`) — how many days of synthetic guide entries to emit per affected channel. Non-numeric values fall back to the default. Clamped to a minimum of 1.

## Behavior

- **Non-destructive.** Channels that already have programmes from the CLI are untouched.
- **Best-effort.** If `index.xml` is missing or unparseable, logs a warning and returns 0 — never breaks the refresh flow.
- **Idempotent on each run.** The CLI rewrites `index.xml` first; we re-augment after. No drift across refreshes.

## Test plan

- [x] `test_synthetic_epg.py` (6 tests): fills only empty channels, uses curated title when known + generic fallback otherwise, no-ops when every channel has programmes, handles missing XML gracefully, formats XMLTV times correctly for naive and aware datetimes, falls back to the default day count on a non-numeric env var.
- [x] Existing suite still passes: `pytest -q` → 37 passed (31 prior + 6 new).
- [x] `ruff check .` + `black --check .` clean.

## Why this lives in the downlink and not in Dispatcharr / Plex

Plex's "fallback EPG" options for HDHR tuners are limited and inconsistent across versions; Dispatcharr's `force_dummy_epg` requires per-channel UI fiddling. Putting it here means every consumer of this downlink — Dispatcharr, Threadfin, Jellyfin, OttPlayer — gets reasonable guide data with zero downstream config. The shape is plain XMLTV; nothing custom.